### PR TITLE
doc/integration.md: typo

### DIFF
--- a/doc/integration.md
+++ b/doc/integration.md
@@ -8,7 +8,7 @@ title: Rspamd integration
 This document describes several methods of integration rspamd to popular MTA. Among them are:
 
 * [Exim](http://exim.org)
-* [Postfix](http://postfix/org)
+* [Postfix](http://postfix.org)
 * [Sendmail](http://sendmail.org)
 * [Haraka](https://haraka.github.io/)
 


### PR DESCRIPTION
It's only the diff about the Postfix URL, the other is probably a newline diff because I've been using the github webui editor.