### PR TITLE
Home page corrections

### DIFF
--- a/_posts/2016-03-21-rspamd-1.2.0.md
+++ b/_posts/2016-03-21-rspamd-1.2.0.md
@@ -8,21 +8,21 @@ The next major release of rspamd: `1.2.0` is now released.
 
 Key features:
 
-* Dynamic rules updates
+* Dynamic rule updates
 * Regular expressions maps support
 * Better performance: pcre2 support, faster fuzzy hashes, faster IP lookups
 * Improved stability: fixed many important bugs and memory leaks
 
-This version is a gradual improvement over the previous `1.1` branch. It is the first release with [rules updates](/doc/modules/rspamd_update.html) support. I believe that it would be easier to backport new rules or critical scores changes from the experimental line to stable one. Rules updates are signed to protect integrity and authenticate the updates source.
+This version is a gradual improvement over the previous `1.1` branch. It is the first release with [rule updates](/doc/modules/rspamd_update.html) support. I believe that it would be easier to backport new rules or critical score changes from the experimental branch to the stable one. Updates are signed to protect their integrity and authenticate the update source.
 
-Among other features introduces by this version are regular expressions maps support (with hyperscan acceleration if available). This sort of maps could be used to match many regular expressions at the same time to detect certain patterns in the messages being scanned.
+Among other features introduced by this version are regular expression maps support (with hyperscan acceleration if available). These maps could be used to match many regular expressions and, at the same time, detect certain patterns in the messages being scanned.
 
-Rspamd 1.2 has a couple of performance improvements: it now supports [PCRE 2](http://pcre.org) regular expressions library that is usually faster than pcre 1. Fuzzy hashing gets further improvements by utilizing AVX2 instructions available from Intel Haswell CPU family. From 1.2 version, rspamd uses better algorithm to store IP addresses allowing to lookup among millions of IPv4 and IPv6 records in almost zero time.
+Rspamd 1.2 has a couple of performance improvements: it now supports the [PCRE 2](http://pcre.org) regular expressions library that is usually faster than pcre 1. Fuzzy hashing gets further improvements by utilizing AVX2 instructions which are available for the Intel Haswell CPU family. From version 1.2 onwards, rspamd uses a better algorithm to store IP addresses allowing lookups among millions of IPv4 and IPv6 records in almost zero time.
 
-The new release is scanned with [Coverity scan](https://scan.coverity.com/) and other static analysis tools that helped to fix many potential bugs and leaks. I believe that rspamd 1.2 is stable, solid and completely production ready so far.
+The new release is scanned with [Coverity scan](https://scan.coverity.com/) and other static analysis tools that helped to fix many potential bugs and leaks. I believe that rspamd 1.2 is stable, solid and completely production-ready so far.
 
-The complete log of changes could be found here: <https://github.com/vstakhov/rspamd/blob/1.2.0/ChangeLog>
+The complete log of changes can be found here: <https://github.com/vstakhov/rspamd/blob/1.2.0/ChangeLog>
 
-There are many important additions in the documentation shipped with rspamd. There is now [frequently asked questions](/doc/faq.html) article that describes many aspects of practical rspamd using. The [quick start guide](/doc/quickstart.html) has been also updated to improve new users' experiences when installing and running rspamd.
+There are many important additions in the documentation shipped with rspamd. There is now a [frequently asked questions](/doc/faq.html) article that describes many aspects of practical rspamd use. The [quick start guide](/doc/quickstart.html) has also been updated to improve new users' experience when installing and running rspamd.
 
-[Rmilter](/rmilter/) has been also upgraded to the version `1.7.5` that fixes important greylisting and clamav issues. Rmilter changelog is available here: <https://github.com/vstakhov/rmilter/blob/1.7.5/ChangeLog>
+[Rmilter](/rmilter/) has been also upgraded to version `1.7.5` which fixes important greylisting and clamav issues. The rmilter changelog is available here: <https://github.com/vstakhov/rmilter/blob/1.7.5/ChangeLog>

--- a/index.md
+++ b/index.md
@@ -8,8 +8,8 @@ title: Rspamd spam filtering system
 			<div>
 					<h2>Performance</h2>
 					<p>&bull;&nbsp;Rspamd is a mail filtering tool that is designed to work as fast as possible.</p>
-					<p>&bull;&nbsp;It can <strong>save</strong> your hardware resources by applying clever techniques, such as event based processing model, <a class="undecor" href="https://highsecure.ru/ast-rspamd.pdf">abstract syntax tree</a> constructions, careful algorithms selection and a number of global and local optimizations, such as use of <a class="undecor" href="https://github.com/01org/hyperscan">hyperscan</a> for <a class="undecor" href="https://highsecure.ru/rspamd-hyperscan.pdf">regular expressions optimization</a>.</p>
-					<p>&bull;&nbsp;Rspamd's core is written completely in C programming language and the most critical parts are written in dedicated assembly for the target hardware platforms.
+					<p>&bull;&nbsp;It can <strong>save</strong> your hardware resources by applying clever techniques, such as an event based processing model, <a class="undecor" href="https://highsecure.ru/ast-rspamd.pdf">abstract syntax tree</a> constructions, careful algorithm selection and a number of global and local optimizations, such as the use of <a class="undecor" href="https://github.com/01org/hyperscan">hyperscan</a> for <a class="undecor" href="https://highsecure.ru/rspamd-hyperscan.pdf">regular expressions optimization</a>.</p>
+					<p>&bull;&nbsp;Rspamd's core is written completely in C and the most critical parts are written in dedicated assembly for the target hardware platforms.
 					</p>
 		 </div>
 		 <a class="btn btn-primary" href="about.html#performance">View details &raquo;</a>
@@ -18,16 +18,16 @@ title: Rspamd spam filtering system
 		  <div>
 					<h2>Features</h2>
 					<p>&bull;&nbsp;Rspamd ships with a wide selection of filters to process messages, such as <a class="undecor" href="/doc/modules/regexp.html">regular expressions</a>, DNS black and white <a class="undecor" href="/doc/modules/rbl.html">lists</a>, <a class="undecor" href="/doc/modules/surbl.html">URL</a> black lists, <a class="undecor" href="/doc/modules/multimap.html">dynamic</a> IP/hosts or DNS lists, <a class="undecor" href="/doc/modules/spf.html">SPF</a> module, <a class="undecor" href="/doc/modules/dkim.html">DKIM</a> plugin and <a class="undecor" href="/doc/modules/dmarc.html">DMARC</a> policy check support.</p>
-				    <p>&bull;&nbsp;For advanced filtering rspamd provides improved statistics module (based on
-					   <a class="undecor" href="http://osbf-lua.luaforge.net/papers/osbf-eddc.pdf">OSB-Bayes algorithm</a>) and <a class="undecor" href="/doc/modules/fuzzy_check.html">fuzzy hashes</a> database that is generated based on <a class="undecor" href="http://en.wikipedia.org/wiki/Honeypot_%28computing%29">honeypot</a> traffic.</p>
-				     <p>&bull;&nbsp;Rspamd also keeps partial compatibility with <a class="undecor" href="http://spamassassin.apache.org">spamassassin</a> rules via <a class="undecor" href="/doc/modules/spamassassin.html">the translation module</a></p>
+				    <p>&bull;&nbsp;For advanced filtering rspamd provides an improved statistics module (based on
+					   <a class="undecor" href="http://osbf-lua.luaforge.net/papers/osbf-eddc.pdf">an OSB-Bayes algorithm</a>) and a <a class="undecor" href="/doc/modules/fuzzy_check.html">fuzzy hashes</a> database that is generated based on <a class="undecor" href="http://en.wikipedia.org/wiki/Honeypot_%28computing%29">honeypot</a> traffic.</p>
+				     <p>&bull;&nbsp;Rspamd also keeps partial compatibility with <a class="undecor" href="http://spamassassin.apache.org">spamassassin</a> rules via <a class="undecor" href="/doc/modules/spamassassin.html">the translation module</a>.</p>
 			</div>
 		  <a class="btn btn-primary" href="about.html#features">View details &raquo;</a>
 	</div>
 	<div class="col-xs-12 col-sm-4 myMainPageText">
 			<div>
 					<h2>Easy to manage</h2>
-					<p>&bull;&nbsp;<a href="/rmilter">Rmilter</a> is a powerful tool that provides <a class="undecor" href="http://www.postfix.org">postfix</a> <a class="undecor" href="/doc/integration.html">integration</a> as well as many other features, such as greylisting, ratelimits and <a class="undecor" href="http://www.clamav.org">clamav</a> checks.</p>
+					<p>&bull;&nbsp;<a href="/rmilter">Rmilter</a> is a powerful tool that provides <a class="undecor" href="http://www.postfix.org">postfix</a> <a class="undecor" href="/doc/integration.html">integration</a> as well as many other features, such as greylisting, rate limits and <a class="undecor" href="http://www.clamav.org">clamav</a> checks.</p>
 					<p>&bull;&nbsp;There is also a nice <a href="/webui/">web interface</a> shipped in the rspamd distribution that simplifies the most common operations and displays statistics.</p>
 					<p>&bull;&nbsp;Moreover, it is possible to <a class="undecor" href="/doc/tutorials/writing_rules.html">write your own rules and plugins</a> for rspamd using the marvelous and simple <a class="undecor" href="http://www.lua.org">Lua</a> language.</p>
       </div>

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ title: Rspamd spam filtering system
 			<div>
 					<h2>Performance</h2>
 					<p>&bull;&nbsp;Rspamd is a mail filtering tool that is designed to work as fast as possible.</p>
-					<p>&bull;&nbsp;It can <strong>save</strong> your hardware resources by applying clever techniques, such as an event based processing model, <a class="undecor" href="https://highsecure.ru/ast-rspamd.pdf">abstract syntax tree</a> constructions, careful algorithm selection and a number of global and local optimizations, such as the use of <a class="undecor" href="https://github.com/01org/hyperscan">hyperscan</a> for <a class="undecor" href="https://highsecure.ru/rspamd-hyperscan.pdf">regular expressions optimization</a>.</p>
+					<p>&bull;&nbsp;It can <strong>save</strong> your hardware resources by applying clever techniques, such as an event based processing model, <a class="undecor" href="https://highsecure.ru/ast-rspamd.pdf">abstract syntax tree</a> constructions, careful algorithm selection and a number of global and local optimisations, such as the use of <a class="undecor" href="https://github.com/01org/hyperscan">hyperscan</a> for <a class="undecor" href="https://highsecure.ru/rspamd-hyperscan.pdf">regular expressions optimisation</a>.</p>
 					<p>&bull;&nbsp;Rspamd's core is written completely in C and the most critical parts are written in dedicated assembly for the target hardware platforms.
 					</p>
 		 </div>


### PR DESCRIPTION
Started with the home page, before moving on to the 'about' page and then hopefully getting straight into the documentation pages.

- Used UK English, over US English i.e. 'optimisation', over 'optimization'
- Just corrected the most recent 'news' (i.e. rspamd-1.2.0.md) which appears on the home page
- Getting to know rspamd better with each reading, so I may update some things as come to understand more