### PR TITLE
Fix & clarify greylisting/replies documentation

### DIFF
--- a/doc/modules/greylisting.md
+++ b/doc/modules/greylisting.md
@@ -27,7 +27,7 @@ This module produces `soft reject` action on greylisting which **SHOULD** be tre
 
 ## Module configuration
 
-First of all, you need to setup Redis server for storing hashes. This procedure is described in detail in the [following document](/doc/configuration/redis.html). Thereafter, you can modify a couple of options specific for greylisting module. It is recommended to define these options in `local.d/greylisting.conf`:
+First of all, you need to setup Redis server for storing hashes. This procedure is described in detail in the [following document](/doc/configuration/redis.html). Thereafter, you can modify a couple of options specific for greylisting module. It is recommended to define these options in `rspamd.conf.local`:
 
 * **`expire`**: setup hashes expire time (1 day by default)
 * **`timeout`**: defines greylisting timeout (5 min by default)
@@ -36,3 +36,10 @@ First of all, you need to setup Redis server for storing hashes. This procedure 
 * **`message`**: a message for temporary rejection reason (`Try again later` by default)
 * **`ipv4_mask`**: mask to apply for IPv4 addresses (19 by default)
 * **`ipv6_mask`**: mask to apply for IPv6 addresses (64 by default)
+
+To enable the module with default settings you could define an empty configuration as shown below:
+
+~~~ucl
+greylist {
+}
+~~~

--- a/doc/modules/replies.md
+++ b/doc/modules/replies.md
@@ -37,6 +37,8 @@ Symbol yielded on messages identified as replies.
 
 ## Example
 
+Configuration should be defined in `rspamd.conf.local`:
+
 ~~~ucl
 replies {
     # This setting is non-default & is required to be set


### PR DESCRIPTION
I'd rather avoid that people may end up using these modules unintentionally, as could be the case with `ratelimit` module currently- so reluctant to create configuration for these in `modules.d`- especially since this stuff is duplicated in `rmilter`. We _could_ create such files in `modules.d` _without_ the `enclosing { }` parts, but I don't see much of a point in that.