### PR TITLE
replace false with no

### DIFF
--- a/rmilter/index.md
+++ b/rmilter/index.md
@@ -48,13 +48,13 @@ From version `1.9.1` it is possible to specify `enable` option in `greylisting` 
 ~~~ucl
 # /etc/rmilter.conf.local
 limits {
-    enable = false;
+    enable = no;
 }
 greylisting {
-    enable = false;
+    enable = no;
 }
 dkim {
-    enable = false;
+    enable = no;
 }
 ~~~
 


### PR DESCRIPTION
i followed your instructions and set limits, greylisting and dkim to enable = false. but it didnt worked as expected. according to milter.conf.sample it should be enabled = no