### PR TITLE
doc/quickstart: Recommend default value of milter_mail_macros for Postfix

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -115,7 +115,7 @@ smtpd_relay_restrictions = check_recipient_access hash:/etc/postfix/access, reje
 smtpd_milters = inet:localhost:11332
 milter_default_action = accept
 milter_protocol = 6
-milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
+milter_mail_macros = i {auth_type} {auth_authen} {auth_author} {mail_addr} {mail_host} {mail_mailer}
 </code></pre>
 </div></div>
 


### PR DESCRIPTION
The default value of mailter_mail_macros as given by `postconf -d` includes
several more macros than recommended by the current documentation. Narrowing
down the value to the currently recommended set might cause issues when using
additional milters like opendkim in a milter chain by starving other milters of
required information. Adding additional milter macros does not seem to cause
any issues with rspamd.